### PR TITLE
chore: update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/generate-map-on-pr.yml
+++ b/.github/workflows/generate-map-on-pr.yml
@@ -10,7 +10,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     
     - name: Install Nix
       uses: cachix/install-nix-action@v31
@@ -18,7 +18,7 @@ jobs:
         nix_path: nixpkgs=channel:nixos-unstable
         
     - name: Setup Nix cache
-      uses: cachix/cachix-action@v12
+      uses: cachix/cachix-action@v17
       with:
         name: devenv
         skipPush: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     
     - name: Install Nix
       uses: cachix/install-nix-action@v31
@@ -20,7 +20,7 @@ jobs:
         nix_path: nixpkgs=channel:nixos-unstable
         
     - name: Setup Nix cache
-      uses: cachix/cachix-action@v12
+      uses: cachix/cachix-action@v17
       with:
         name: devenv
         skipPush: true
@@ -34,7 +34,7 @@ jobs:
         nix develop --command python -m pytest tests/ --cov=. --cov-report=xml --cov-report=term-missing -v
     
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v5
       with:
         file: ./coverage.xml
         fail_ci_if_error: false
@@ -44,7 +44,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     
     - name: Install Nix
       uses: cachix/install-nix-action@v31
@@ -52,7 +52,7 @@ jobs:
         nix_path: nixpkgs=channel:nixos-unstable
         
     - name: Setup Nix cache
-      uses: cachix/cachix-action@v12
+      uses: cachix/cachix-action@v17
       with:
         name: devenv
         skipPush: true


### PR DESCRIPTION
Updated GitHub Actions to their latest versions:\n- actions/checkout: v4 → v6\n- cachix/cachix-action: v12 → v17\n- codecov/codecov-action: v3 → v5